### PR TITLE
fixed Print Button bug - updated filePath

### DIFF
--- a/src/papillon/controllers/CheckController.java
+++ b/src/papillon/controllers/CheckController.java
@@ -119,7 +119,7 @@ public class CheckController{
 	public void printCheck(){
 		int invoice = currentCheck.getInvoiceNumber();
 		String printOutput = checkPanel.getCheckFormat();
-		String filePath = "src/papillon/resources/printOutput/";
+		String filePath = "src/papillon/resources/";
 		String fileName = filePath + invoice + ".txt";
 		PrintWriter out = null;
 		try{


### PR DESCRIPTION
Print button was giving "Error creating print output for invoice number ......." error on console when you hit it. The old path that used to exist was no longer there, so I had updated the filePath in CheckController class for the printCheck() function. Works now. Please verify.
